### PR TITLE
fix(go-modules): update module path

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,4 +33,4 @@ linters-settings:
     sections:
       - standard
       - default
-      - prefix(github.com/enterprise-contract/go-gather)
+      - prefix(github.com/conforma/go-gather)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,44 +1,44 @@
-## [0.1.1](https://github.com/enterprise-contract/go-gather/compare/v0.1.0...v0.1.1) (2025-02-05)
+## [0.1.1](https://github.com/conforma/go-gather/compare/v0.1.0...v0.1.1) (2025-02-05)
 
 ### Bug Fixes
 
-* **detector-tests:** Fixed detector tests. ([00ac820](https://github.com/enterprise-contract/go-gather/commit/00ac820fcfebad39bf4c93ddf71e5c32cc954a6e))
+* **detector-tests:** Fixed detector tests. ([00ac820](https://github.com/conforma/go-gather/commit/00ac820fcfebad39bf4c93ddf71e5c32cc954a6e))
 
-## [0.1.0](https://github.com/enterprise-contract/go-gather/compare/v0.0.8...v0.1.0) (2025-02-03)
+## [0.1.0](https://github.com/conforma/go-gather/compare/v0.0.8...v0.1.0) (2025-02-03)
 
 ### Features
 
-* **detector:** Add new Detector functionality. ([5b89b1d](https://github.com/enterprise-contract/go-gather/commit/5b89b1d25470f5545496aa3965c2a3c69c62992a))
+* **detector:** Add new Detector functionality. ([5b89b1d](https://github.com/conforma/go-gather/commit/5b89b1d25470f5545496aa3965c2a3c69c62992a))
 
-## [0.0.8](https://github.com/enterprise-contract/go-gather/compare/v0.0.7...v0.0.8) (2025-02-03)
-
-### Bug Fixes
-
-* **deps:** update module github.com/go-git/go-git/v5 to v5.13.2 ([a34f303](https://github.com/enterprise-contract/go-gather/commit/a34f303f7ab8cab26dc2ba8b0a93c7e4e05de698))
-
-## [0.0.7](https://github.com/enterprise-contract/go-gather/compare/v0.0.6...v0.0.7) (2025-01-28)
-
-## [0.0.6](https://github.com/enterprise-contract/go-gather/compare/v0.0.5...v0.0.6) (2025-01-10)
+## [0.0.8](https://github.com/conforma/go-gather/compare/v0.0.7...v0.0.8) (2025-02-03)
 
 ### Bug Fixes
 
-* TLS or not determination ([7ac9200](https://github.com/enterprise-contract/go-gather/commit/7ac92008c381e8a198e18df011328e6cb708f657))
+* **deps:** update module github.com/go-git/go-git/v5 to v5.13.2 ([a34f303](https://github.com/conforma/go-gather/commit/a34f303f7ab8cab26dc2ba8b0a93c7e4e05de698))
 
-## [0.0.5](https://github.com/enterprise-contract/go-gather/compare/v0.0.4...v0.0.5) (2024-11-25)
+## [0.0.7](https://github.com/conforma/go-gather/compare/v0.0.6...v0.0.7) (2025-01-28)
 
-### Bug Fixes
-
-* **deps:** update module github.com/stretchr/testify to v1.10.0 ([24a578f](https://github.com/enterprise-contract/go-gather/commit/24a578f8b72c419c6d0afa4322792cc4788c2683))
-
-## [0.0.4](https://github.com/enterprise-contract/go-gather/compare/v0.0.3...v0.0.4) (2024-10-21)
+## [0.0.6](https://github.com/conforma/go-gather/compare/v0.0.5...v0.0.6) (2025-01-10)
 
 ### Bug Fixes
 
-* Added missing "v" in tagFormat in .releaserc ([fa2b652](https://github.com/enterprise-contract/go-gather/commit/fa2b652ecb9552efc848631224ea928bc37ea793))
-* call ClassifyURI on destinations in copyFile ([aacce9f](https://github.com/enterprise-contract/go-gather/commit/aacce9f74ac9f3d151326938a6b12107f4783631))
+* TLS or not determination ([7ac9200](https://github.com/conforma/go-gather/commit/7ac92008c381e8a198e18df011328e6cb708f657))
 
-## [0.0.4](https://github.com/enterprise-contract/go-gather/compare/v0.0.3...0.0.4) (2024-10-21)
+## [0.0.5](https://github.com/conforma/go-gather/compare/v0.0.4...v0.0.5) (2024-11-25)
 
 ### Bug Fixes
 
-* call ClassifyURI on destinations in copyFile ([aacce9f](https://github.com/enterprise-contract/go-gather/commit/aacce9f74ac9f3d151326938a6b12107f4783631))
+* **deps:** update module github.com/stretchr/testify to v1.10.0 ([24a578f](https://github.com/conforma/go-gather/commit/24a578f8b72c419c6d0afa4322792cc4788c2683))
+
+## [0.0.4](https://github.com/conforma/go-gather/compare/v0.0.3...v0.0.4) (2024-10-21)
+
+### Bug Fixes
+
+* Added missing "v" in tagFormat in .releaserc ([fa2b652](https://github.com/conforma/go-gather/commit/fa2b652ecb9552efc848631224ea928bc37ea793))
+* call ClassifyURI on destinations in copyFile ([aacce9f](https://github.com/conforma/go-gather/commit/aacce9f74ac9f3d151326938a6b12107f4783631))
+
+## [0.0.4](https://github.com/conforma/go-gather/compare/v0.0.3...0.0.4) (2024-10-21)
+
+### Bug Fixes
+
+* call ClassifyURI on destinations in copyFile ([aacce9f](https://github.com/conforma/go-gather/commit/aacce9f74ac9f3d151326938a6b12107f4783631))

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ go-gather is based heavily on [go-getter](https://github.com/hashicorp/go-getter
 
 Installation can be done with a normal go get:
 ```
-$ go get github.com/enterprise-contract/go-gather
+$ go get github.com/conforma/go-gather
 ```
 
 ## Security

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -17,10 +17,10 @@
 package detector
 
 import (
-	"github.com/enterprise-contract/go-gather/gather/file"
-	"github.com/enterprise-contract/go-gather/gather/git"
-	"github.com/enterprise-contract/go-gather/gather/http"
-	"github.com/enterprise-contract/go-gather/gather/oci"
+	"github.com/conforma/go-gather/gather/file"
+	"github.com/conforma/go-gather/gather/git"
+	"github.com/conforma/go-gather/gather/http"
+	"github.com/conforma/go-gather/gather/oci"
 )
 
 // FileDetector checks if the URI is a file path.

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -81,7 +81,7 @@ func TestGitDetector(t *testing.T) {
 		},
 		{
 			name:     "valid git HTTPS URI",
-			uri:      "https://github.com/enterprise-contract/go-gather.git",
+			uri:      "https://github.com/conforma/go-gather.git",
 			expected: true,
 		},
 		{

--- a/examples/expand/bzip2/expand_bzip2.go
+++ b/examples/expand/bzip2/expand_bzip2.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/enterprise-contract/go-gather/expand/bzip2"
+	"github.com/conforma/go-gather/expand/bzip2"
 )
 
 func main() {

--- a/examples/expand/tar/expand_tar.go
+++ b/examples/expand/tar/expand_tar.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
-	tarExpander "github.com/enterprise-contract/go-gather/expand/tar"
+	tarExpander "github.com/conforma/go-gather/expand/tar"
 )
 
 func main() {

--- a/examples/expand/zip/expand_zip.go
+++ b/examples/expand/zip/expand_zip.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
-	zipExpander "github.com/enterprise-contract/go-gather/expand/zip"
+	zipExpander "github.com/conforma/go-gather/expand/zip"
 )
 
 func main() {

--- a/examples/gather/file/gather_file.go
+++ b/examples/gather/file/gather_file.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/enterprise-contract/go-gather/gather/file"
+	"github.com/conforma/go-gather/gather/file"
 )
 
 

--- a/examples/gather/git/gather_git.go
+++ b/examples/gather/git/gather_git.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/enterprise-contract/go-gather/gather/git"
+	"github.com/conforma/go-gather/gather/git"
 )
 
 func main() {
@@ -30,7 +30,7 @@ func main() {
 	// -------------------------------------------------------------------------
 
 	// Set the source URL to the git repository
-	gitSrc := "git://github.com/enterprise-contract/go-gather.git"
+	gitSrc := "git://github.com/conforma/go-gather.git"
 
 	// Create a temporary directory to act as our destination directory
 	dst, err := os.MkdirTemp("", "git_gather_example_dst_")

--- a/examples/gather/http/gather_http.go
+++ b/examples/gather/http/gather_http.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/enterprise-contract/go-gather/gather/http"
+	"github.com/conforma/go-gather/gather/http"
 )
 
 func main(){

--- a/examples/gather/oci/gather_oci.go
+++ b/examples/gather/oci/gather_oci.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/enterprise-contract/go-gather/gather/oci"
+	"github.com/conforma/go-gather/gather/oci"
 )
 
 func main() {

--- a/examples/registry/expander/get_expander.go
+++ b/examples/registry/expander/get_expander.go
@@ -19,7 +19,7 @@ package main
 import (
 	"reflect"
 
-	"github.com/enterprise-contract/go-gather/registry"
+	"github.com/conforma/go-gather/registry"
 )
 
 func main() {

--- a/examples/registry/gather/get_gatherer.go
+++ b/examples/registry/gather/get_gatherer.go
@@ -19,7 +19,7 @@ package main
 import (
 	"reflect"
 
-	"github.com/enterprise-contract/go-gather/registry"
+	"github.com/conforma/go-gather/registry"
 )
 
 func main(){
@@ -29,7 +29,7 @@ func main(){
 	//-------------------------------------------------------------------------
 
 	// Set the source URL to the file
-	srcs := []string{"file:///tmp/test.bz2", "https://www.google.com/index.html", "git://github.com/enterprise-contract/go-gather.git", "oci::quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3"}
+	srcs := []string{"file:///tmp/test.bz2", "https://www.google.com/index.html", "git://github.com/conforma/go-gather.git", "oci::quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3"}
 
 	for _, src := range srcs {
 		// Get the gatherer for the given source URL

--- a/expand/bzip2/bzip2.go
+++ b/expand/bzip2/bzip2.go
@@ -25,8 +25,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/enterprise-contract/go-gather/expand"
-	"github.com/enterprise-contract/go-gather/internal/helpers"
+	"github.com/conforma/go-gather/expand"
+	"github.com/conforma/go-gather/internal/helpers"
 )
 
 var pathExpanderFunc = helpers.ExpandPath

--- a/expand/bzip2/bzip2_test.go
+++ b/expand/bzip2/bzip2_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/enterprise-contract/go-gather/internal/helpers"
+	"github.com/conforma/go-gather/internal/helpers"
 )
 
 // helloBzip2Fixture is a small bzip2-encoded byte slice that decompresses to "Hello Bzip2!".

--- a/expand/tar/tar.go
+++ b/expand/tar/tar.go
@@ -29,8 +29,8 @@ import (
 
 	"github.com/google/safearchive/tar"
 
-	"github.com/enterprise-contract/go-gather/expand"
-	"github.com/enterprise-contract/go-gather/internal/helpers"
+	"github.com/conforma/go-gather/expand"
+	"github.com/conforma/go-gather/internal/helpers"
 )
 
 var (

--- a/expand/zip/zip.go
+++ b/expand/zip/zip.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/google/safearchive/zip"
 
-	"github.com/enterprise-contract/go-gather/expand"
-	"github.com/enterprise-contract/go-gather/internal/helpers"
+	"github.com/conforma/go-gather/expand"
+	"github.com/conforma/go-gather/internal/helpers"
 )
 
 var pathExpanderFunc = helpers.ExpandPath

--- a/expand/zip/zip_test.go
+++ b/expand/zip/zip_test.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	customzip "github.com/enterprise-contract/go-gather/expand/zip"
+	customzip "github.com/conforma/go-gather/expand/zip"
 )
 
 // TestZipExpander_Matcher verifies that the Matcher function correctly identifies .zip files.

--- a/gather/file/file.go
+++ b/gather/file/file.go
@@ -25,10 +25,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/enterprise-contract/go-gather/expand"
-	"github.com/enterprise-contract/go-gather/gather"
-	"github.com/enterprise-contract/go-gather/internal/helpers"
-	"github.com/enterprise-contract/go-gather/metadata"
+	"github.com/conforma/go-gather/expand"
+	"github.com/conforma/go-gather/gather"
+	"github.com/conforma/go-gather/internal/helpers"
+	"github.com/conforma/go-gather/metadata"
 )
 
 type FileGatherer struct {

--- a/gather/file/file_test.go
+++ b/gather/file/file_test.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/enterprise-contract/go-gather/expand"
-	_ "github.com/enterprise-contract/go-gather/expand/zip" // Register zip expander
+	"github.com/conforma/go-gather/expand"
+	_ "github.com/conforma/go-gather/expand/zip" // Register zip expander
 )
 
 func TestFileGatherer_Matcher(t *testing.T) {

--- a/gather/gather_test.go
+++ b/gather/gather_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/enterprise-contract/go-gather/metadata"
+	"github.com/conforma/go-gather/metadata"
 )
 
 type TestGatherer struct{}

--- a/gather/gatherer.go
+++ b/gather/gatherer.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/enterprise-contract/go-gather/metadata"
+	"github.com/conforma/go-gather/metadata"
 )
 
 type Gatherer interface {

--- a/gather/git/git.go
+++ b/gather/git/git.go
@@ -33,8 +33,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 
-	"github.com/enterprise-contract/go-gather/gather"
-	"github.com/enterprise-contract/go-gather/metadata"
+	"github.com/conforma/go-gather/gather"
+	"github.com/conforma/go-gather/metadata"
 )
 
 type GitGatherer struct {

--- a/gather/http/http.go
+++ b/gather/http/http.go
@@ -27,9 +27,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/enterprise-contract/go-gather/gather"
-	"github.com/enterprise-contract/go-gather/internal/helpers"
-	"github.com/enterprise-contract/go-gather/metadata"
+	"github.com/conforma/go-gather/gather"
+	"github.com/conforma/go-gather/internal/helpers"
+	"github.com/conforma/go-gather/metadata"
 )
 
 var Transport http.RoundTripper = http.DefaultTransport

--- a/gather/oci/oci.go
+++ b/gather/oci/oci.go
@@ -30,9 +30,9 @@ import (
 	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote"
 
-	"github.com/enterprise-contract/go-gather/gather"
-	r "github.com/enterprise-contract/go-gather/internal/oci/registry"
-	"github.com/enterprise-contract/go-gather/metadata"
+	"github.com/conforma/go-gather/gather"
+	r "github.com/conforma/go-gather/internal/oci/registry"
+	"github.com/conforma/go-gather/metadata"
 )
 
 type OCIGatherer struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/enterprise-contract/go-gather
+module github.com/conforma/go-gather
 
 go 1.22.7
 

--- a/internal/oci/registry/client.go
+++ b/internal/oci/registry/client.go
@@ -25,7 +25,7 @@ import (
 	"oras.land/oras-go/v2/registry/remote/credentials"
 	"oras.land/oras-go/v2/registry/remote/retry"
 
-	"github.com/enterprise-contract/go-gather/internal/oci/network"
+	"github.com/conforma/go-gather/internal/oci/network"
 )
 
 /* This code is sourced from the open-policy-agent/conftest project. */

--- a/registry/expand.go
+++ b/registry/expand.go
@@ -17,10 +17,10 @@
 package registry
 
 import (
-	expander "github.com/enterprise-contract/go-gather/expand"
-	_ "github.com/enterprise-contract/go-gather/expand/bzip2"
-	_ "github.com/enterprise-contract/go-gather/expand/tar"
-	_ "github.com/enterprise-contract/go-gather/expand/zip"
+	expander "github.com/conforma/go-gather/expand"
+	_ "github.com/conforma/go-gather/expand/bzip2"
+	_ "github.com/conforma/go-gather/expand/tar"
+	_ "github.com/conforma/go-gather/expand/zip"
 )
 
 func GetExpander(extension string) expander.Expander {

--- a/registry/gather.go
+++ b/registry/gather.go
@@ -17,11 +17,11 @@
 package registry
 
 import (
-	"github.com/enterprise-contract/go-gather/gather"
-	_ "github.com/enterprise-contract/go-gather/gather/file"
-	_ "github.com/enterprise-contract/go-gather/gather/git"
-	_ "github.com/enterprise-contract/go-gather/gather/http"
-	_ "github.com/enterprise-contract/go-gather/gather/oci"
+	"github.com/conforma/go-gather/gather"
+	_ "github.com/conforma/go-gather/gather/file"
+	_ "github.com/conforma/go-gather/gather/git"
+	_ "github.com/conforma/go-gather/gather/http"
+	_ "github.com/conforma/go-gather/gather/oci"
 )
 
 func GetGatherer(uri string) (gather.Gatherer, error) {


### PR DESCRIPTION
This commit updates the go.mod file to reflect the new organization name 'conforma'. All future module imports should reference `github.com/conforma/go-gather` instead of
`github.com/enterprise-contract/go-gather`.

Ref: EC-1106

BREAKING CHANGE: Users must update import paths and dependencies to the new module path. Run `go get github.com/conforma/go-gather@latest` and `go mod tidy` to resolve.