### PR TITLE
fix: update Matcher() function in `gather/file`

### DIFF
--- a/gather/file/file.go
+++ b/gather/file/file.go
@@ -53,7 +53,18 @@ func (f *FileGatherer) Matcher(uri string) bool {
 			return true
 		}
 	}
-	return false
+
+	// Return true if the URI is a file path relative to the current working directory.
+	_, err := os.Stat(uri)
+    if err == nil {
+        return true
+    }
+    if os.IsNotExist(err) {
+        return false // file does not exist, so it is not a file path.
+    }
+    // If we reach here, the error is due to something else (e.g., permission error).
+	fmt.Printf("Error: %v\n", err)
+    return false
 }
 
 func (f *FileGatherer) Gather(ctx context.Context, src, dst string) (metadata.Metadata, error) {

--- a/gather/file/file_test.go
+++ b/gather/file/file_test.go
@@ -33,6 +33,12 @@ import (
 func TestFileGatherer_Matcher(t *testing.T) {
 	fg := &FileGatherer{}
 
+	// create a temporary file for testing relative paths
+	if _, err := os.Create("myTempFile"); err != nil {
+		t.Fatalf("failed to create temporary file: %v", err)
+	}
+	defer os.Remove("myTempFile")
+
 	tests := []struct {
 		name string
 		uri  string
@@ -43,6 +49,8 @@ func TestFileGatherer_Matcher(t *testing.T) {
 		{"absolute path", "/etc/hosts", true},
 		{"relative path dot", "./myfile", true},
 		{"relative path dotdot", "../myfile", true},
+		{"relative path with no dot", "myTempFile", true},
+		{"relative path with no dot that doesn't exist", "myOtherTempFile", false},
 		{"no match", "http://example.com/file.txt", false},
 	}
 


### PR DESCRIPTION
This commit addresses a bug file in
https://github.com/enterprise-contract/ec-cli/issues/2346 regarding handling of relative file paths that aren't prefixed with `./`

Ref: EC-1158