### PR TITLE
fix(metadata): fix returns  on `Gather()` methods

### DIFF
--- a/gather/file/file.go
+++ b/gather/file/file.go
@@ -143,7 +143,7 @@ func (f *FileGatherer) Gather(ctx context.Context, src, dst string) (metadata.Me
 	return fsaver.save(ctx, src, dst, false)
 }
 
-func (f *FSMetadata) Get() interface{} {
+func (f FSMetadata) Get() interface{} {
 	return f
 }
 
@@ -207,7 +207,7 @@ func (f *FileSaver) save(ctx context.Context, source string, destination string,
 	f.Size = writtenSize
 	f.Timestamp = time.Now().Format(time.RFC3339)
 
-	return &f.FSMetadata, nil
+	return f.FSMetadata, nil
 }
 
 func getExpander(src string) (expand.Expander, error) {

--- a/gather/file/file_test.go
+++ b/gather/file/file_test.go
@@ -86,7 +86,7 @@ func TestFileGatherer_Gather_File(t *testing.T) {
 		t.Fatalf("expected file %s to exist, but it does not", dstFile)
 	}
 
-	fsMeta, ok := meta.(*FSMetadata)
+	fsMeta, ok := meta.(FSMetadata)
 	if !ok {
 		t.Fatalf("expected FSMetadata, got %T", meta)
 	}

--- a/gather/git/git.go
+++ b/gather/git/git.go
@@ -177,13 +177,13 @@ func (g *GitGatherer) Gather(ctx context.Context, src, dst string) (metadata.Met
 		return nil, fmt.Errorf("determining the HEAD reference: %w", err)
 	}
 
-	m := &GitMetadata{
+	m := GitMetadata{
 		LatestCommit: head.Hash().String(),
 	}
 	return m, nil
 }
 
-func (g *GitMetadata) Get() interface{} {
+func (g GitMetadata) Get() interface{} {
 	return g
 }
 

--- a/gather/http/http.go
+++ b/gather/http/http.go
@@ -141,7 +141,7 @@ func (h *HTTPGatherer) Gather(ctx context.Context, rawSource, dst string) (metad
 	h.Size = bytesWritten
 	h.Timestamp = time.Now().Format(time.RFC3339)
 
-	return &h.HTTPMetadata, nil
+	return h.HTTPMetadata, nil
 }
 
 func (h *HTTPGatherer) Matcher(uri string) bool {
@@ -154,7 +154,7 @@ func (h *HTTPGatherer) Matcher(uri string) bool {
 	return false
 }
 
-func (h *HTTPMetadata) Get() interface{} {
+func (h HTTPMetadata) Get() interface{} {
 	return h
 }
 

--- a/gather/http/http_test.go
+++ b/gather/http/http_test.go
@@ -78,7 +78,7 @@ func TestHTTPGatherer_Gather_Success(t *testing.T) {
 		t.Errorf("expected content %q, got %q", testData, string(fileContent))
 	}
 
-	httpMeta, ok := meta.(*HTTPMetadata)
+	httpMeta, ok := meta.(HTTPMetadata)
 	if !ok {
 		t.Fatalf("expected *HTTPMetadata, got %T", meta)
 	}
@@ -174,7 +174,7 @@ func TestHTTPGatherer_Gather_EmptyDirDestination(t *testing.T) {
 		t.Fatalf("Gather returned error: %v", err)
 	}
 
-	httpMeta := meta.(*HTTPMetadata)
+	httpMeta := meta.(HTTPMetadata)
 	expectedPath := filepath.Join(dest, "download-me.bin")
 	if httpMeta.Path != expectedPath {
 		t.Errorf("expected path=%s, got %s", expectedPath, httpMeta.Path)

--- a/gather/oci/oci.go
+++ b/gather/oci/oci.go
@@ -108,7 +108,7 @@ func (o *OCIGatherer) Gather(ctx context.Context, source, dst string) (metadata.
 	o.Path = dst
 	o.Timestamp = time.Now().Format(time.RFC3339)
 
-	return &o.OCIMetadata, nil
+	return o.OCIMetadata, nil
 }
 
 func (o *OCIGatherer) Matcher(uri string) bool {
@@ -122,7 +122,7 @@ func (o *OCIGatherer) Matcher(uri string) bool {
 	return containsOCIRegistry(uri)
 }
 
-func (o *OCIMetadata) Get() interface{} {
+func (o OCIMetadata) Get() interface{} {
 	return o
 }
 

--- a/gather/oci/oci_test.go
+++ b/gather/oci/oci_test.go
@@ -87,7 +87,7 @@ func TestOCIGatherer_Gather_Success(t *testing.T) {
 		t.Fatalf("Gather returned an error: %v", err)
 	}
 
-	ociMeta, ok := meta.(*OCIMetadata)
+	ociMeta, ok := meta.(OCIMetadata)
 	if !ok {
 		t.Fatalf("expected *OCIMetadata, got %T", meta)
 	}
@@ -247,7 +247,7 @@ func pushTestArtifact(m *memory.Store, finalRef string, data []byte) error {
 
 // Optional TestOCIMetadata_Get to show retrieving the raw metadata structure
 func TestOCIMetadata_Get(t *testing.T) {
-	o := &OCIMetadata{
+	o := OCIMetadata{
 		Path:      "/tmp/some/path",
 		Digest:    "sha256:123abc",
 		Timestamp: time.Now().Format(time.RFC3339),


### PR DESCRIPTION
This commit updates the returned values for `Gather()` methods for `file`, `git`, `http`, and `oci`. Previously these had returned pointers to their respective metadata types, resulting in errors when calling their respective `GetPinnedUrl()` methods as noted in EC-1163

Ref: EC-1163