### PR TITLE
chore(build): add checks for pushes

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,70 @@
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: Checks
+
+"on":
+    pull_request:
+        branches:
+        - main
+    push:
+        branches:
+        - main
+    workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+
+  Test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        with:
+          egress-policy: audit
+          disable-telemetry: true
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Restore Cache
+        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          key: main
+          path: '**'
+
+      - name: Setup Go environment
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
+          cache: false
+          
+      - name: Check for uncommitted changes
+        run: |
+          if ! git diff --exit-code -s; then
+            for f in $(git diff --exit-code --name-only); do
+              echo "::error file=$f,line=1,col=1,endColumn=1::File was modified in build"
+            done
+            exit 1
+          fi
+
+      - name: Test
+        run: make test

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,13 +1,17 @@
 name: Release Go-Gather
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Checks"]
+    types:
+      - completed
     branches:
-      - main # Trigger on pushes to the main branch
+      - main
   workflow_dispatch:
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }} # Only run if "Checks" succeeded
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This commit adds a `checks` workflow that checks for uncommited changes as well as execution of tests on pushes to main or pull-requests targeting main.

This commit also updates the `tag` workflow to require that the `checks` workflow successfully completes before attempting to tag a new release.