### PR TITLE
chore(renovate): use recommended configs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,32 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":gitSignOff",
+    ":disableDependencyDashboard"
+  ],
+  "ignorePresets": [
+    ":dependencyDashboard"
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "timezone": "American/New_York",
+  "schedule": ["0-59 7-15 * * 1-5"],
+  "baseBranches": ["main"],
+  "packageRules": [
+    { "matchManagers": ["gomod"], 
+      "matchDepNames": ["go"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPaths": ["/"],
+      "groupName": "gomod / Updates"
+    },
+    {
+      "matchManagers": ["pre-commit"],
+      "groupName": "Pre-commit Updates"
+    }
   ]
 }


### PR DESCRIPTION
This commit adopts recommended configs, disables dependency dashboard, enables vulnerability alerts, sets a weekly schedule, disables go version updates, and groups gomod and pre-commit updates -- respectively.

Ref: [EC-1068](https://issues.redhat.com/browse/EC-1068)